### PR TITLE
Adds the monitor-nifi-fb-ingest Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Role Variables
 
 * `sre_tooling_enabled_services`: A list of services to augment the SRE Tooling application. Supported values are:
   1. `infra-index-update`: Installs a systemd timer that updates the index of the host (and optionally the hostname) within a group of cloud resources.
+  2. `monitor-nifi-fb-ingest`: Installs a systemd time that hits the specified NiFi Flow Bulletin Board and sends the bulletins to Sentry.
 
 
 Example Playbook
@@ -22,6 +23,8 @@ Here's an example of how to run the role in a playbook:
       vars:
         sre_tooling_enabled_services:
           - infra-index-update
+          - monitor-nifi-fb-ingest
+        sre_tooling_monitor_nifi_fb_ingest_sentry_dsn: "https:fasfwefwrw@sentry.com/testorg/1"
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ sre_tooling_install_dir: "/usr/local/bin"
 sre_tooling_data_dir: "/var/lib/sre-tooling"
 sre_tooling_system_user: "root"
 sre_tooling_system_group: "root"
-sre_tooling_version: "0.4.0"
+sre_tooling_version: "0.7.0"
 sre_tooling_download_url: "https://github.com/onaio/sre-tooling/releases/download/v{{ sre_tooling_version }}/sre-tooling_{{ sre_tooling_version }}_linux_amd64.tar.gz"
 sre_tooling_environment_file: "/etc/default/sre-tooling"
 # List of global (available to all services) environment vairables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,17 @@
 ---
 # defaults file for role
 sre_tooling_install_dir: "/usr/local/bin"
+sre_tooling_data_dir: "/var/lib/sre-tooling"
 sre_tooling_system_user: "root"
 sre_tooling_system_group: "root"
 sre_tooling_version: "0.4.0"
 sre_tooling_download_url: "https://github.com/onaio/sre-tooling/releases/download/v{{ sre_tooling_version }}/sre-tooling_{{ sre_tooling_version }}_linux_amd64.tar.gz"
 sre_tooling_environment_file: "/etc/default/sre-tooling"
+# List of global (available to all services) environment vairables
+sre_tooling_environment:
+  SRE_MONITORING_NIFI_FLOW_BULLETIN_URL: "http://127.0.0.1:8080/nifi-api/flow/bulletin-board"
+  SRE_MONITORING_NIFI_FLOW_BULLETIN_SENTRY_DSN: "{{ sre_tooling_monitor_nifi_fb_ingest_sentry_dsn }}"
+  SRE_NIFI_SYSTEM_DIAGNOSTICS_URL: "http://127.0.0.1:8080/nifi-api/system-diagnostics"
 # Which SRE Tooling services to install. Possible values are:
 #  - infra-index-update: Updates the index of the host in a group and possibly its hostname
 sre_tooling_enabled_services: []
@@ -24,3 +30,11 @@ sre_tooling_infra_update_flags: "-filter-region=\"${AWS_REGION}\" -filter-tag=\"
 sre_tooling_infra_update_set_hostname: true
 sre_tooling_infra_update_hostname_prefix: "${INSTANCE_GROUP}-"
 sre_tooling_infra_update_default_hostname: "{{ sre_tooling_infra_update_hostname_prefix }}0"
+
+# monitoring nifi bulletin flow ingest service
+# FB stands for Flow Bulletin
+sre_tooling_monitor_nifi_fb_ingest_sentry_dsn: ""
+sre_tooling_monitor_nifi_fb_ingest_data_dir: "{{ sre_tooling_data_dir }}"
+sre_tooling_monitor_nifi_fb_ingest_systemd_on_boot_sec: 2min
+sre_tooling_monitor_nifi_fb_ingest_systemd_on_active_sec: 1min
+sre_tooling_monitor_nifi_fb_ingest_systemd_rand_sec: 0sec

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,3 +6,10 @@
     daemon_reload: true
     enabled: true
     state: restarted
+
+- name: restart sre_tooling_monitor_nifi_fb_ingest_service_name systemd timer
+  systemd:
+    name: "{{ sre_tooling_monitor_nifi_fb_ingest_service_name }}.timer"
+    daemon_reload: true
+    enabled: true
+    state: restarted

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,6 +4,7 @@
   vars:
     sre_tooling_enabled_services:
       - infra-index-update
+      - monitor-nifi-fb-ingest
   tasks:
     - name: "Include role"
       include_role:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -4,10 +4,18 @@
 - name: Verify
   hosts: all
   tasks:
-    - name: Run systemctl is-enabled on sre-tooling-infra-index-update.timer
-      command: systemctl is-enabled sre-tooling-infra-index-update.timer
-      register: _infra_index_systemd_timer_status
+    - name: Run systemctl is-enabled
+      command: "systemctl is-enabled {{ _cur_service }}"
+      register: _service_statuses
+      loop:
+        - sre-tooling-infra-index-update.timer
+        - sre-tooling-monitor-nifi-fb-ingest.timer
+      loop_control:
+        loop_var: _cur_service
 
-    - name: Check if sre-tooling-infra-index-update.timer is enabled
+    - name: Check if systemd service/timer is enabled
       assert:
-        that: _infra_index_systemd_timer_status.rc == 0
+        that: _cur_service_status.rc == 0
+      loop: "{{ _service_statuses.results }}"
+      loop_control:
+        loop_var: _cur_service_status

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -17,9 +17,17 @@
     mode: 0551
 
 - name: Create the SRE Tooling environment file
-  file:
-    path: "{{ sre_tooling_environment_file }}"
-    state: touch
+  template:
+    src: "sre_tooling_environment_file"
+    dest: "{{ sre_tooling_environment_file }}"
     owner: "{{ sre_tooling_system_user }}"
     group: "{{ sre_tooling_system_group }}"
     mode: 0640
+
+- name: Create the SRE Tooling data directory
+  file:
+    path: "{{ sre_tooling_data_dir }}"
+    state: directory
+    owner: "{{ sre_tooling_system_user }}"
+    group: "{{ sre_tooling_system_group }}"
+    mode: 0750

--- a/tasks/service/monitor-nifi-fb-ingest.yml
+++ b/tasks/service/monitor-nifi-fb-ingest.yml
@@ -1,0 +1,15 @@
+---
+- name: Copy the systemd service and timer files
+  template:
+    src: "etc/systemd/system/sre_tooling_monitor_nifi_fb_ingest_service_name.{{ _cur_file }}.j2"
+    dest: "/etc/systemd/system/{{ sre_tooling_monitor_nifi_fb_ingest_service_name }}.{{ _cur_file }}"
+    owner: root
+    group: root
+    mode: 0644
+  loop_control:
+    loop_var: _cur_file
+  loop:
+    - service
+    - timer
+  notify:
+    - restart sre_tooling_monitor_nifi_fb_ingest_service_name systemd timer

--- a/templates/etc/systemd/system/sre_tooling_monitor_nifi_fb_ingest_service_name.service.j2
+++ b/templates/etc/systemd/system/sre_tooling_monitor_nifi_fb_ingest_service_name.service.j2
@@ -1,0 +1,15 @@
+
+[Unit]
+Description=SRE Tooling NiFi flow bulletin monitoring service
+After=network.target
+
+[Service]
+User={{ sre_tooling_system_user }}
+Group={{ sre_tooling_system_group }}
+Type=simple
+ExecStart={{ sre_tooling_install_path }} monitoring nifi bulletin flow ingest -persistence-dir="{{ sre_tooling_monitor_nifi_fb_ingest_data_dir }}"
+EnvironmentFile=-{{ sre_tooling_environment_file }}
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/etc/systemd/system/sre_tooling_monitor_nifi_fb_ingest_service_name.timer.j2
+++ b/templates/etc/systemd/system/sre_tooling_monitor_nifi_fb_ingest_service_name.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=SRE Tooling NiFi flow bulletin monitoring timer
+
+[Timer]
+OnBootSec={{ sre_tooling_monitor_nifi_fb_ingest_systemd_on_boot_sec }}
+OnUnitActiveSec={{ sre_tooling_monitor_nifi_fb_ingest_systemd_on_active_sec }}
+RandomizedDelaySec={{ sre_tooling_monitor_nifi_fb_ingest_systemd_rand_sec }}
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/templates/sre_tooling_environment_file
+++ b/templates/sre_tooling_environment_file
@@ -1,0 +1,5 @@
+{% if sre_tooling_environment is iterable %}
+{% for envKey,envValue in sre_tooling_environment.items() %}
+{{ envKey }}={{ envValue }}
+{% endfor %}
+{% endif %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,3 +2,4 @@
 # vars file for role
 sre_tooling_install_path: "{{ sre_tooling_install_dir }}/sre-tooling"
 sre_tooling_infra_index_service_name: "sre-tooling-infra-index-update"
+sre_tooling_monitor_nifi_fb_ingest_service_name: "sre-tooling-monitor-nifi-fb-ingest"


### PR DESCRIPTION
Adds the monitor-nifi-fb-ingest service for monitoring the NiFi flow
bulletin endpoint and sending the bulletins there to a Sentry DSN.

Blocked by https://github.com/onaio/sre-tooling/pull/15