### PR TITLE
Uses OnActiveSec Instead of OnUnitActiveSec on Timers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ sre_tooling_install_dir: "/usr/local/bin"
 sre_tooling_data_dir: "/var/lib/sre-tooling"
 sre_tooling_system_user: "root"
 sre_tooling_system_group: "root"
-sre_tooling_version: "0.7.0"
+sre_tooling_version: "0.7.1"
 sre_tooling_download_url: "https://github.com/onaio/sre-tooling/releases/download/v{{ sre_tooling_version }}/sre-tooling_{{ sre_tooling_version }}_linux_amd64.tar.gz"
 sre_tooling_environment_file: "/etc/default/sre-tooling"
 # List of global (available to all services) environment vairables

--- a/templates/etc/systemd/system/sre_tooling_infra_index_service_name.timer.j2
+++ b/templates/etc/systemd/system/sre_tooling_infra_index_service_name.timer.j2
@@ -3,7 +3,7 @@ Description=SRE Tooling infrastructure index update timer
 
 [Timer]
 OnBootSec={{ sre_tooling_infra_update_systemd_on_boot_sec }}
-OnUnitActiveSec={{ sre_tooling_infra_update_systemd_on_active_sec }}
+OnActiveSec={{ sre_tooling_infra_update_systemd_on_active_sec }}
 RandomizedDelaySec={{ sre_tooling_infra_update_systemd_rand_sec }}
 Persistent=true
 

--- a/templates/etc/systemd/system/sre_tooling_monitor_nifi_fb_ingest_service_name.timer.j2
+++ b/templates/etc/systemd/system/sre_tooling_monitor_nifi_fb_ingest_service_name.timer.j2
@@ -3,7 +3,7 @@ Description=SRE Tooling NiFi flow bulletin monitoring timer
 
 [Timer]
 OnBootSec={{ sre_tooling_monitor_nifi_fb_ingest_systemd_on_boot_sec }}
-OnUnitActiveSec={{ sre_tooling_monitor_nifi_fb_ingest_systemd_on_active_sec }}
+OnActiveSec={{ sre_tooling_monitor_nifi_fb_ingest_systemd_on_active_sec }}
 RandomizedDelaySec={{ sre_tooling_monitor_nifi_fb_ingest_systemd_rand_sec }}
 Persistent=true
 


### PR DESCRIPTION
For the systemd timers, use OnActiveSec to measure how long the timer
should wait before firing again. There are some situations where
OnUnitActiveSec doesn't work (situations where the service isn't
initially fired at all).

Signed-off-by: Jason Rogena <jason@rogena.me>