### PR TITLE
Use OnCalendar in systemd Timers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,8 +18,7 @@ sre_tooling_enabled_services: []
 
 # infra update service
 sre_tooling_infra_update_region: "${SRE_TOOLING_REGION}"
-sre_tooling_infra_update_systemd_on_boot_sec: 2min
-sre_tooling_infra_update_systemd_on_active_sec: 1h
+sre_tooling_infra_update_systemd_on_calendar: "hourly"
 sre_tooling_infra_update_systemd_rand_sec: 5min
 sre_tooling_infra_update_instance_group: "${SRE_TOOLING_SERVER_GROUP}"
 sre_tooling_infra_update_env:
@@ -35,6 +34,5 @@ sre_tooling_infra_update_default_hostname: "{{ sre_tooling_infra_update_hostname
 # FB stands for Flow Bulletin
 sre_tooling_monitor_nifi_fb_ingest_sentry_dsn: ""
 sre_tooling_monitor_nifi_fb_ingest_data_dir: "{{ sre_tooling_data_dir }}"
-sre_tooling_monitor_nifi_fb_ingest_systemd_on_boot_sec: 2min
-sre_tooling_monitor_nifi_fb_ingest_systemd_on_active_sec: 1min
+sre_tooling_monitor_nifi_fb_ingest_systemd_on_calendar: "minutely"
 sre_tooling_monitor_nifi_fb_ingest_systemd_rand_sec: 0sec

--- a/templates/etc/systemd/system/sre_tooling_infra_index_service_name.timer.j2
+++ b/templates/etc/systemd/system/sre_tooling_infra_index_service_name.timer.j2
@@ -2,8 +2,7 @@
 Description=SRE Tooling infrastructure index update timer
 
 [Timer]
-OnBootSec={{ sre_tooling_infra_update_systemd_on_boot_sec }}
-OnActiveSec={{ sre_tooling_infra_update_systemd_on_active_sec }}
+OnCalendar={{ sre_tooling_infra_update_systemd_on_calendar }}
 RandomizedDelaySec={{ sre_tooling_infra_update_systemd_rand_sec }}
 Persistent=true
 

--- a/templates/etc/systemd/system/sre_tooling_monitor_nifi_fb_ingest_service_name.timer.j2
+++ b/templates/etc/systemd/system/sre_tooling_monitor_nifi_fb_ingest_service_name.timer.j2
@@ -2,8 +2,7 @@
 Description=SRE Tooling NiFi flow bulletin monitoring timer
 
 [Timer]
-OnBootSec={{ sre_tooling_monitor_nifi_fb_ingest_systemd_on_boot_sec }}
-OnActiveSec={{ sre_tooling_monitor_nifi_fb_ingest_systemd_on_active_sec }}
+OnCalendar={{ sre_tooling_monitor_nifi_fb_ingest_systemd_on_calendar }}
 RandomizedDelaySec={{ sre_tooling_monitor_nifi_fb_ingest_systemd_rand_sec }}
 Persistent=true
 


### PR DESCRIPTION
Use OnCalendar in the systemd timers installed by this role, instead of
OnActiveSec which is known to be unreliable.

Related to systemd/systemd#5840

Signed-off-by: Jason Rogena <jason@rogena.me>