### PR TITLE
Run Index Update Script Soon After Boot

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,7 @@ sre_tooling_enabled_services: []
 # infra update service
 sre_tooling_infra_update_region: "${SRE_TOOLING_REGION}"
 sre_tooling_infra_update_systemd_on_calendar: "hourly"
+sre_tooling_infra_update_systemd_on_boot_sec: 2min
 sre_tooling_infra_update_systemd_rand_sec: 5min
 sre_tooling_infra_update_instance_group: "${SRE_TOOLING_SERVER_GROUP}"
 sre_tooling_infra_update_env:

--- a/templates/etc/systemd/system/sre_tooling_infra_index_service_name.timer.j2
+++ b/templates/etc/systemd/system/sre_tooling_infra_index_service_name.timer.j2
@@ -3,6 +3,7 @@ Description=SRE Tooling infrastructure index update timer
 
 [Timer]
 OnCalendar={{ sre_tooling_infra_update_systemd_on_calendar }}
+OnBootSec={{ sre_tooling_infra_update_systemd_on_boot_sec }}
 RandomizedDelaySec={{ sre_tooling_infra_update_systemd_rand_sec }}
 Persistent=true
 


### PR DESCRIPTION
Add an `OnBootSec` directive to the index update systemd timer with a
default value of 2min so that the index update sub-command is called
soon after a server is booted, rather than wait for the top of the hour
to do so.

Signed-off-by: Jason Rogena <jason@rogena.me>